### PR TITLE
Split macros for readability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,5 @@ tauri = "1.5.2"
 default = [ "event" ]
 event   = [ "tauri-interop-macro/event" ]
 leptos  = [ "dep:leptos", "tauri-interop-macro/leptos" ]
-# used to generated the missing documentation only generated for "target_family = wasm"
+# used to generate the missing documentation, otherwise it's only generated for "target_family = wasm"
 wasm    = []

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 ![License](https://img.shields.io/crates/l/tauri-interop.svg)
 
 What this crate tries to achieve:
-- generate a equal wasm-function from your defined `tauri::command`
-- collect all defined `tauri::command`s without adding them manually
-- a simplified way to sending events from tauri and receiving them in the frontend
+- generate a equal wasm-function for your defined `tauri::command`
+- collecting all defined `tauri::command`s without adding them manually
+- a way to sending events from tauri and receiving them in the frontend
 
 
 ## Basic usage:
@@ -41,8 +41,8 @@ Using `tauri_interop::command` does two things:
 - it provides the command with two macros which are used depending on the `target_family`
   - `tauri_interop::binding` is used when compiling to `wasm`
   - `tauri::command` is used otherwise
-- it adds an entry to `tauri_interop::collect_commands!()` so that the generated 
-  `get_commands()` function includes/registers the given commands for the tauri context
+- it adds an entry to `tauri_interop::collect_commands!()` so that the generated `get_handlers()` function includes the given commands for the tauri context
+  - the function is not generated when targeting `wasm`
 
 The defined command above can then be used in wasm as below. Due to receiving data from 
 tauri via a promise, the command response has to be awaited.
@@ -64,13 +64,13 @@ fn main() {
 
 #### Command representation Host/Wasm
 
-- technically all commands need to be of type `Result<T, E>`
-  - where E is a error that the command isn't defined, if not explicitly redefined via the return type
-  - this error will show up in the web console, so there shouldn't be a problem ignoring it
+- the returned type of the wasm binding should be 1:1 the same type as send from the "backend" 
+  - technically all commands need to be of type `Result<T, E>` because there is always the possibility of a command getting called, that isn't registered in the context of tauri
+    - when using `tauri_interop::collect_commands!()` this possibility is near fully removed
+    - for convenience, we ignore that possibility, and even if the error occurs it will be logged into the console
 - all arguments with type "State", "AppHandle" and "Window" are removed automatically
 > the current implementation relies on the name of the type and can not separate between a 
 > tauri::State and a self defined "State" struct
-- asynchronous commands are values as is seen [async-commands](https://tauri.app/v1/guides/features/command#async-commands) for a detail explanation
 
 ```rust , ignore-wasm32-unknown-unknown
 // let _: () = trigger_something();
@@ -95,7 +95,7 @@ async fn asynchronous_execution(change: bool) -> Result<String, String> {
     }
 }
 
-// let _wait_for_completion: () = asynchronous_execution(true).await;
+// let _wait_for_completion: () = heavy_computation().await;
 #[tauri_interop::command]
 async fn heavy_computation() {
   std::thread::sleep(std::time::Duration::from_millis(5000))
@@ -117,10 +117,9 @@ pub struct Test {
 fn main() {}
 ```
 
-Using `tauri_interop::emit_or_listen` does provides the command with two macros,
-which are used depending on the `target_family`
-  - `tauri_interop::listen_to` is used when compiling to `wasm`
-  - derive trait `tauri_interop::Emit` is used otherwise
+When using the derive macro `tauri_interop::Event` it expands depending on the `target_family` to
+  - derive trait `tauri_interop::Listen` (when compiling to `wasm`)
+  - derive trait `tauri_interop::Emit` (otherwise)
 
 To emit a variable from the above struct (which is mostly intended to be used as state) in the host triplet
 ```rust , ignore-wasm32-unknown-unknown
@@ -162,7 +161,9 @@ fn main() {
 
 the above emitted value can then be received in wasm as:
 ```rust , ignore
-#[tauri_interop::emit_or_listen]
+use tauri_interop::Event;
+
+#[derive(Default, Event)]
 pub struct Test {
     foo: String,
     pub bar: bool,
@@ -175,17 +176,19 @@ async fn main() {
 }
 ```
 
-The `liste_handle` contains the provided closure and the "unlisten" method. It has to be hold in scope as long 
+The `ListenHandle` contains the provided closure and the "unlisten" method. It has to be hold in scope as long 
 as the event should be received. Dropping it will automatically detach the closure from the event. See 
 [cmd.rs](./test-project/api/src/cmd.rs) for other example how it could be used.
 
 #### Feature: leptos
 When the `leptos` feature is enabled it will add additional `use_<field>` methods on the provided struct.
-These methods take care of the required initial asynchron call to register the listener and will hold the
+These methods take care of the required initial asynchronous call to register the listener and will hold the
 handle in scope as long as the component is rendered.
 
 ```rust , ignore
-#[tauri_interop::emit_or_listen]
+use tauri_interop::Event;
+
+#[derive(Default, Event)]
 pub struct Test {
     foo: String,
     pub bar: bool,

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,6 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 #[cfg(not(target_family = "wasm"))]
-use tauri::{AppHandle, Wry, Error};
+use tauri::{AppHandle, Error, Wry};
 
 /// traits for event emitting in the host code (feat: `tauri`)
 #[cfg(not(target_family = "wasm"))]
@@ -44,7 +44,7 @@ where
 
     #[cfg(not(target_family = "wasm"))]
     /// Updates the related field and emit its event
-    /// 
+    ///
     /// Only required for "target_family = wasm"
     fn update(s: &mut P, handle: &AppHandle<Wry>, v: Self::Type) -> Result<(), Error>;
 }

--- a/src/event/listen.rs
+++ b/src/event/listen.rs
@@ -115,7 +115,6 @@ impl<'s> ListenHandle<'s> {
     }
 }
 
-
 /// Trait that defines the available listen methods
 pub trait Listen {
     /// Registers an callback to a [Field]
@@ -134,9 +133,7 @@ pub trait Listen {
     ///
     /// Default Implementation: see [ListenHandle::use_register]
     #[cfg(feature = "leptos")]
-    fn use_field<F: Field<Self>>(
-        initial: F::Type,
-    ) -> (ReadSignal<F::Type>, WriteSignal<F::Type>)
+    fn use_field<F: Field<Self>>(initial: F::Type) -> (ReadSignal<F::Type>, WriteSignal<F::Type>)
     where
         Self: Sized + super::Parent,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
-
 #![feature(trait_alias)]
 
 /// wasm bindings for tauri's provided js functions (target: `wasm` or feat: `wasm`)

--- a/tauri-interop-macro/src/command.rs
+++ b/tauri-interop-macro/src/command.rs
@@ -1,0 +1,59 @@
+use crate::command::wrapper::{InvokeArgument, InvokeCommand};
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use quote::{format_ident, quote, ToTokens};
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
+use syn::{parse_macro_input, FnArg, ItemFn};
+
+mod wrapper;
+
+pub fn convert_to_binding(stream: TokenStream) -> TokenStream {
+    let item_fn = parse_macro_input!(stream as ItemFn);
+    let InvokeCommand {
+        attributes,
+        name,
+        generics,
+        return_type,
+        invoke,
+        invoke_argument,
+    } = wrapper::prepare(item_fn);
+
+    let InvokeArgument {
+        argument_name,
+        fields,
+    } = invoke_argument;
+
+    let async_ident = invoke.as_async();
+    let field_usage = fields
+        .iter()
+        .map(|field| field.ident.clone())
+        .collect::<Punctuated<Ident, Comma>>();
+    let field_definitions = fields
+        .into_iter()
+        .map(|field| field.argument)
+        .collect::<Punctuated<FnArg, Comma>>();
+
+    let command_name = name.to_string();
+    let args_ident = format_ident!("args");
+    let invoke_binding = invoke.as_expr(command_name, &args_ident);
+
+    let stream = quote! {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        struct #argument_name #generics {
+            #field_definitions
+        }
+
+        #( #attributes )*
+        pub #async_ident fn #name #generics (#field_definitions) #return_type
+        {
+            let #args_ident = #argument_name { #field_usage };
+            let #args_ident = ::serde_wasm_bindgen::to_value(&#args_ident)
+                .expect("serialized arguments");
+
+            #invoke_binding
+        }
+    };
+
+    TokenStream::from(stream.to_token_stream())
+}

--- a/tauri-interop-macro/src/command/wrapper.rs
+++ b/tauri-interop-macro/src/command/wrapper.rs
@@ -1,0 +1,164 @@
+use convert_case::{Case, Casing};
+use proc_macro::Span;
+use proc_macro2::Ident;
+use quote::{format_ident, ToTokens};
+use syn::{
+    parse_quote, Attribute, Expr, ExprPath, FnArg, GenericParam, Generics, ItemFn, Lifetime,
+    LifetimeParam, Pat, PathSegment, ReturnType, Signature, Type, TypePath,
+};
+
+#[derive(PartialEq)]
+pub enum Invoke {
+    Empty,
+    AsyncEmpty,
+    Async,
+    AsyncResult,
+}
+
+impl Invoke {
+    pub fn as_async(&self) -> Option<Ident> {
+        self.ne(&Invoke::Empty).then_some(format_ident!("async"))
+    }
+
+    pub fn as_expr(&self, cmd_name: String, arg_name: &Ident) -> Expr {
+        let expr: ExprPath = match self {
+            Invoke::Empty => parse_quote!(bindings::invoke),
+            Invoke::Async | Invoke::AsyncEmpty => parse_quote!(command::async_invoke),
+            Invoke::AsyncResult => parse_quote!(command::invoke_catch),
+        };
+
+        let call = parse_quote!( ::tauri_interop::#expr(#cmd_name, #arg_name) );
+
+        if self.as_async().is_some() {
+            Expr::Await(parse_quote!(#call.await))
+        } else {
+            Expr::Call(call)
+        }
+    }
+}
+
+fn is_result(segment: &PathSegment) -> bool {
+    segment.ident.to_string().as_str() == "Result"
+}
+
+fn determine_invoke(return_type: &ReturnType, is_async: bool) -> Invoke {
+    match return_type {
+        ReturnType::Default => {
+            if is_async {
+                Invoke::AsyncEmpty
+            } else {
+                Invoke::Empty
+            }
+        }
+        ReturnType::Type(_, ty) => match ty.as_ref() {
+            // fixme: if it's an single ident, catch isn't needed this could probably be a problem later
+            Type::Path(path) if path.path.segments.iter().any(is_result) => Invoke::AsyncResult,
+            Type::Path(_) => Invoke::Async,
+            others => panic!("no support for '{}'", others.to_token_stream()),
+        },
+    }
+}
+
+const ARGUMENT_LIFETIME: &str = "'arg_lifetime";
+
+fn new_arg_lt() -> Lifetime {
+    Lifetime::new(ARGUMENT_LIFETIME, Span::call_site().into())
+}
+
+const TAURI_TYPES: [&str; 3] = ["State", "AppHandle", "Window"];
+
+fn any_tauri(ty_path: &TypePath) -> bool {
+    ty_path
+        .path
+        .segments
+        .iter()
+        .any(|segment| TAURI_TYPES.contains(&segment.ident.to_string().as_str()))
+}
+
+pub struct InvokeCommand {
+    pub attributes: Vec<Attribute>,
+    pub name: Ident,
+    pub generics: Generics,
+    pub return_type: ReturnType,
+    pub invoke: Invoke,
+    pub invoke_argument: InvokeArgument,
+}
+
+pub struct InvokeArgument {
+    pub argument_name: Ident,
+    pub fields: Vec<FieldArg>,
+}
+
+pub struct FieldArg {
+    pub ident: Ident,
+    pub argument: FnArg,
+    requires_lifetime: bool,
+}
+
+pub fn prepare(function: ItemFn) -> InvokeCommand {
+    let ItemFn {
+        attrs: attributes,
+        sig,
+        ..
+    } = function;
+
+    let Signature {
+        ident: name,
+        mut generics,
+        inputs,
+        output: return_type,
+        asyncness,
+        ..
+    } = sig;
+
+    let filtered_fields = inputs
+        .into_iter()
+        .filter_map(|mut fn_arg| {
+            let typed = match fn_arg {
+                FnArg::Typed(ref mut typed) => typed,
+                _ => return None,
+            };
+
+            if matches!(typed.ty.as_ref(), Type::Path(ty_path) if any_tauri(ty_path)) {
+                return None;
+            }
+
+            let req_lf = if let Type::Reference(ty_ref) = typed.ty.as_mut() {
+                ty_ref.lifetime = Some(new_arg_lt());
+                true
+            } else {
+                false
+            };
+
+            match typed.pat.as_ref() {
+                Pat::Ident(ident) => Some(FieldArg {
+                    ident: ident.ident.clone(),
+                    argument: fn_arg,
+                    requires_lifetime: req_lf,
+                }),
+                _ => None,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if filtered_fields.iter().any(|field| field.requires_lifetime) {
+        generics
+            .params
+            .push(GenericParam::Lifetime(LifetimeParam::new(new_arg_lt())))
+    }
+
+    let invoke = determine_invoke(&return_type, asyncness.is_some());
+    let argument_name = format_ident!("{}Args", name.to_string().to_case(Case::Pascal));
+
+    InvokeCommand {
+        attributes,
+        name,
+        generics,
+        return_type,
+        invoke,
+        invoke_argument: InvokeArgument {
+            argument_name,
+            fields: filtered_fields,
+        },
+    }
+}

--- a/tauri-interop-macro/src/event.rs
+++ b/tauri-interop-macro/src/event.rs
@@ -43,8 +43,8 @@ fn prepare(stream_struct: ItemStruct) -> Event {
             let field_name = field_ident.to_string().to_case(Case::Pascal);
 
             EventField {
-                name: field_ident.clone(),
-                field: format_ident!("{field_name}"),
+                name: format_ident!("{field_name}"),
+                field: field_ident.clone(),
                 ty: field.ty.clone(),
             }
         })

--- a/tauri-interop-macro/src/event.rs
+++ b/tauri-interop-macro/src/event.rs
@@ -1,0 +1,113 @@
+use std::fmt::Display;
+use convert_case::{Case, Casing};
+use proc_macro2::Ident;
+use quote::format_ident;
+use syn::{ItemStruct, Type, Attribute, DeriveInput};
+
+pub(crate) mod emit;
+pub(crate) mod listen;
+
+struct Event {
+    ident: Ident,
+    mod_name: Ident,
+    fields: Vec<EventField>,
+}
+
+struct EventField {
+    name: Ident,
+    field: Ident,
+    ty: Type,
+}
+
+fn prepare(stream_struct: ItemStruct) -> Event {
+    if stream_struct.fields.is_empty() {
+        panic!("No fields provided")
+    }
+
+    if stream_struct
+        .fields
+        .iter()
+        .any(|field| field.ident.is_none())
+    {
+        panic!("Tuple Structs aren't supported")
+    }
+
+    let struct_name = &stream_struct.ident;
+    let mod_name = struct_name.to_string().to_case(Case::Snake);
+
+    let fields = stream_struct
+        .fields
+        .iter()
+        .map(|field| {
+            let field_ident = field.ident.as_ref().unwrap();
+            let field_name = field_ident.to_string().to_case(Case::Pascal);
+
+            EventField {
+                name: field_ident.clone(),
+                field: format_ident!("{field_name}"),
+                ty: field.ty.clone(),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Event {
+        ident: struct_name.clone(),
+        mod_name: format_ident!("{mod_name}"),
+        fields,
+    }
+}
+
+struct Field {
+    ident: Ident,
+    attributes: FieldAttributes,
+    event: String,
+}
+
+struct FieldAttributes {
+    pub parent: Ident,
+    pub name: Option<Ident>,
+    pub ty: Type,
+}
+
+fn get_field_values(attrs: Vec<Attribute>) -> FieldAttributes {
+    let parent = attrs
+        .iter()
+        .find(|a| a.path().is_ident("parent"))
+        .expect("expected parent attribute")
+        .parse_args()
+        .unwrap();
+
+    let name = attrs
+        .iter()
+        .find(|a| a.path().is_ident("field_name"))
+        .and_then(|name| name.parse_args().ok());
+
+    let ty = attrs
+        .iter()
+        .find(|a| a.path().is_ident("field_ty"))
+        .expect("expected ty attribute")
+        .parse_args()
+        .unwrap();
+
+    FieldAttributes { parent, name, ty }
+}
+
+/// function to build the same unique event name for wasm and host triplet
+fn get_event_name<S, F>(struct_name: &S, field_name: &F) -> String
+    where
+        S: Display,
+        F: Display,
+{
+    format!("{struct_name}::{field_name}")
+}
+
+fn prepare_field(derive_input: DeriveInput) -> Field {
+    let ident = derive_input.ident.clone();
+    let attributes = get_field_values(derive_input.attrs);
+
+    Field{
+        event: get_event_name(&attributes.parent, &ident),
+        ident,
+        attributes,
+    }
+}

--- a/tauri-interop-macro/src/event.rs
+++ b/tauri-interop-macro/src/event.rs
@@ -1,25 +1,24 @@
-use std::fmt::Display;
 use convert_case::{Case, Casing};
 use proc_macro2::Ident;
 use quote::format_ident;
-use syn::{ItemStruct, Type, Attribute, DeriveInput};
+use syn::{Attribute, DeriveInput, ItemStruct, Type};
 
 pub(crate) mod emit;
 pub(crate) mod listen;
 
-struct Event {
-    ident: Ident,
+struct EventStruct {
+    name: Ident,
     mod_name: Ident,
     fields: Vec<EventField>,
 }
 
 struct EventField {
-    name: Ident,
-    field: Ident,
-    ty: Type,
+    field_name: Ident,
+    parent_field_name: Ident,
+    parent_field_ty: Type,
 }
 
-fn prepare(stream_struct: ItemStruct) -> Event {
+fn prepare_event(stream_struct: ItemStruct) -> EventStruct {
     if stream_struct.fields.is_empty() {
         panic!("No fields provided")
     }
@@ -32,41 +31,41 @@ fn prepare(stream_struct: ItemStruct) -> Event {
         panic!("Tuple Structs aren't supported")
     }
 
-    let struct_name = &stream_struct.ident;
-    let mod_name = struct_name.to_string().to_case(Case::Snake);
+    let name = stream_struct.ident.clone();
+    let mod_name = format_ident!("{}", name.to_string().to_case(Case::Snake));
 
     let fields = stream_struct
         .fields
         .iter()
         .map(|field| {
             let field_ident = field.ident.as_ref().unwrap();
-            let field_name = field_ident.to_string().to_case(Case::Pascal);
+            let field_name = format_ident!("{}", field_ident.to_string().to_case(Case::Pascal));
 
             EventField {
-                name: format_ident!("{field_name}"),
-                field: field_ident.clone(),
-                ty: field.ty.clone(),
+                field_name,
+                parent_field_name: field_ident.clone(),
+                parent_field_ty: field.ty.clone(),
             }
         })
         .collect::<Vec<_>>();
 
-    Event {
-        ident: struct_name.clone(),
-        mod_name: format_ident!("{mod_name}"),
+    EventStruct {
+        name,
+        mod_name,
         fields,
     }
 }
 
 struct Field {
-    ident: Ident,
+    name: Ident,
     attributes: FieldAttributes,
-    event: String,
+    event_name: String,
 }
 
 struct FieldAttributes {
     pub parent: Ident,
-    pub name: Option<Ident>,
-    pub ty: Type,
+    pub parent_field_name: Option<Ident>,
+    pub parent_field_ty: Type,
 }
 
 fn get_field_values(attrs: Vec<Attribute>) -> FieldAttributes {
@@ -77,37 +76,33 @@ fn get_field_values(attrs: Vec<Attribute>) -> FieldAttributes {
         .parse_args()
         .unwrap();
 
-    let name = attrs
+    let parent_field_name = attrs
         .iter()
-        .find(|a| a.path().is_ident("field_name"))
+        .find(|a| a.path().is_ident("parent_field_name"))
         .and_then(|name| name.parse_args().ok());
 
-    let ty = attrs
+    let parent_field_ty = attrs
         .iter()
-        .find(|a| a.path().is_ident("field_ty"))
+        .find(|a| a.path().is_ident("parent_field_ty"))
         .expect("expected ty attribute")
         .parse_args()
         .unwrap();
 
-    FieldAttributes { parent, name, ty }
-}
-
-/// function to build the same unique event name for wasm and host triplet
-fn get_event_name<S, F>(struct_name: &S, field_name: &F) -> String
-    where
-        S: Display,
-        F: Display,
-{
-    format!("{struct_name}::{field_name}")
+    FieldAttributes {
+        parent,
+        parent_field_name,
+        parent_field_ty,
+    }
 }
 
 fn prepare_field(derive_input: DeriveInput) -> Field {
-    let ident = derive_input.ident.clone();
+    let name = derive_input.ident.clone();
     let attributes = get_field_values(derive_input.attrs);
+    let event_name = format!("{}::{}", &attributes.parent, &name);
 
-    Field{
-        event: get_event_name(&attributes.parent, &ident),
-        ident,
+    Field {
+        event_name,
+        name,
         attributes,
     }
 }

--- a/tauri-interop-macro/src/event/emit.rs
+++ b/tauri-interop-macro/src/event/emit.rs
@@ -1,0 +1,101 @@
+use crate::event::{Event, EventField, Field, FieldAttributes};
+use proc_macro::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{parse_macro_input, DeriveInput, ItemStruct};
+
+pub fn derive(stream: TokenStream) -> TokenStream {
+    let stream_struct = parse_macro_input!(stream as ItemStruct);
+    let Event {
+        ident,
+        mod_name,
+        fields,
+    } = super::prepare(stream_struct);
+
+    let emit_fields = fields.iter().map(|field| {
+        let EventField { name, field, ty } = field;
+
+        quote! {
+            #[allow(dead_code)]
+            #[derive(::tauri_interop::EmitField)]
+            #[parent(#ident)]
+            #[field_name(#field)]
+            #[field_ty(#ty)]
+            pub struct #name;
+        }
+    });
+
+    let event_fields = fields.iter().map(|field| &field.name);
+
+    let stream = quote! {
+        use tauri_interop::event::{Field, emit::Emit};
+
+        pub mod #mod_name {
+            use super::#ident;
+            use tauri_interop::event::{Field, emit::Emit};
+
+            // to each field a defined struct tuple is generated
+            #( #emit_fields )*
+        }
+
+        impl Emit for #ident {
+            fn emit_all(&self, handle: &::tauri::AppHandle) -> Result<(), ::tauri::Error> {
+                use #mod_name::*;
+
+                #( #event_fields::emit(self, handle)?; )*
+
+                Ok(())
+            }
+
+            fn emit<F: Field<Self>>(&self, handle: &::tauri::AppHandle) -> Result<(), ::tauri::Error>
+            where
+                Self: Sized
+            {
+                F::emit(self, handle)
+            }
+
+            fn update<F: Field<Self>>(&mut self, handle: &::tauri::AppHandle, field: F::Type) -> Result<(), ::tauri::Error>
+            where
+                Self: Sized
+            {
+                F::update(self, handle, field)
+            }
+        }
+    };
+
+    TokenStream::from(stream.to_token_stream())
+}
+
+pub fn derive_field(stream: TokenStream) -> TokenStream {
+    let derive_input = syn::parse_macro_input!(stream as DeriveInput);
+
+    let Field {
+        ident,
+        attributes,
+        event,
+    } = super::prepare_field(derive_input);
+
+    let FieldAttributes { parent, name, ty } = attributes;
+
+    name.as_ref().expect("name attribute was expected");
+
+    let stream = quote! {
+        impl Field<#parent> for #ident {
+            type Type = #ty;
+
+            fn emit(parent: &#parent, handle: &::tauri::AppHandle) -> Result<(), ::tauri::Error> {
+                use ::tauri::Manager;
+
+                log::trace!("Emitted event [{}]", #event);
+
+                handle.emit_all(#event, parent.#name.clone())
+            }
+
+            fn update(parent: &mut #parent, handle: &::tauri::AppHandle, v: Self::Type) -> Result<(), ::tauri::Error> {
+                parent.#name = v;
+                Self::emit(parent, handle)
+            }
+        }
+    };
+
+    TokenStream::from(stream.to_token_stream())
+}

--- a/tauri-interop-macro/src/event/emit.rs
+++ b/tauri-interop-macro/src/event/emit.rs
@@ -1,43 +1,46 @@
-use crate::event::{Event, EventField, Field, FieldAttributes};
+use crate::event::{EventField, EventStruct, Field, FieldAttributes};
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{parse_macro_input, DeriveInput, ItemStruct};
 
 pub fn derive(stream: TokenStream) -> TokenStream {
     let stream_struct = parse_macro_input!(stream as ItemStruct);
-    let Event {
-        ident,
+    let EventStruct {
+        name,
         mod_name,
         fields,
-    } = super::prepare(stream_struct);
+    } = super::prepare_event(stream_struct);
 
     let emit_fields = fields.iter().map(|field| {
-        let EventField { name, field, ty } = field;
+        let EventField {
+            field_name,
+            parent_field_name,
+            parent_field_ty,
+        } = field;
 
         quote! {
             #[allow(dead_code)]
             #[derive(::tauri_interop::EmitField)]
-            #[parent(#ident)]
-            #[field_name(#field)]
-            #[field_ty(#ty)]
-            pub struct #name;
+            #[parent(#name)]
+            #[parent_field_name(#parent_field_name)]
+            #[parent_field_ty(#parent_field_ty)]
+            pub struct #field_name;
         }
     });
 
-    let event_fields = fields.iter().map(|field| &field.name);
+    let event_fields = fields.iter().map(|field| &field.field_name);
 
     let stream = quote! {
         use tauri_interop::event::{Field, emit::Emit};
 
         pub mod #mod_name {
-            use super::#ident;
+            use super::#name;
             use tauri_interop::event::{Field, emit::Emit};
 
-            // to each field a defined struct tuple is generated
             #( #emit_fields )*
         }
 
-        impl Emit for #ident {
+        impl Emit for #name {
             fn emit_all(&self, handle: &::tauri::AppHandle) -> Result<(), ::tauri::Error> {
                 use #mod_name::*;
 
@@ -69,29 +72,35 @@ pub fn derive_field(stream: TokenStream) -> TokenStream {
     let derive_input = syn::parse_macro_input!(stream as DeriveInput);
 
     let Field {
-        ident,
+        name,
         attributes,
-        event,
+        event_name,
     } = super::prepare_field(derive_input);
 
-    let FieldAttributes { parent, name, ty } = attributes;
+    let FieldAttributes {
+        parent,
+        parent_field_name,
+        parent_field_ty,
+    } = attributes;
 
-    name.as_ref().expect("name attribute was expected");
+    parent_field_name
+        .as_ref()
+        .expect("name attribute was expected");
 
     let stream = quote! {
-        impl Field<#parent> for #ident {
-            type Type = #ty;
+        impl Field<#parent> for #name {
+            type Type = #parent_field_ty;
 
             fn emit(parent: &#parent, handle: &::tauri::AppHandle) -> Result<(), ::tauri::Error> {
                 use ::tauri::Manager;
 
-                log::trace!("Emitted event [{}]", #event);
+                log::trace!("Emitted event [{}]", #event_name);
 
-                handle.emit_all(#event, parent.#name.clone())
+                handle.emit_all(#event_name, parent.#parent_field_name.clone())
             }
 
             fn update(parent: &mut #parent, handle: &::tauri::AppHandle, v: Self::Type) -> Result<(), ::tauri::Error> {
-                parent.#name = v;
+                parent.#parent_field_name = v;
                 Self::emit(parent, handle)
             }
         }

--- a/tauri-interop-macro/src/event/listen.rs
+++ b/tauri-interop-macro/src/event/listen.rs
@@ -1,0 +1,59 @@
+use crate::event::{Event, EventField, Field, FieldAttributes};
+use proc_macro::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{parse_macro_input, ItemStruct, DeriveInput};
+
+pub fn derive(stream: TokenStream) -> TokenStream {
+    let stream_struct = parse_macro_input!(stream as ItemStruct);
+    let Event {
+        ident,
+        mod_name,
+        fields,
+    } = super::prepare(stream_struct);
+
+    let listen_fields = fields.iter().map(|field| {
+        let EventField { name, ty, .. } = field;
+
+        quote! {
+            #[allow(dead_code)]
+            #[derive(::tauri_interop::ListenField)]
+            #[parent(#ident)]
+            #[field_ty(#ty)]
+            pub struct #name;
+        }
+    });
+
+    let stream = quote! {
+        pub mod #mod_name {
+            use super::#ident;
+            use ::tauri_interop::event::Field;
+
+            #( #listen_fields )*
+        }
+
+        impl ::tauri_interop::event::listen::Listen for #ident {}
+    };
+
+    TokenStream::from(stream.to_token_stream())
+}
+
+pub fn derive_field(stream: TokenStream) -> TokenStream {
+    let derive_input = syn::parse_macro_input!(stream as DeriveInput);
+
+    let Field {
+        ident,
+        attributes,
+        event,
+    } = super::prepare_field(derive_input);
+
+    let FieldAttributes { parent, ty, .. } = attributes;
+
+    let stream = quote! {
+        impl Field<#parent> for #ident {
+            type Type = #ty;
+            const EVENT_NAME: &'static str = #event;
+        }
+    };
+
+    TokenStream::from(stream.to_token_stream())
+}

--- a/tauri-interop-macro/src/lib.rs
+++ b/tauri-interop-macro/src/lib.rs
@@ -39,7 +39,7 @@ pub fn derive_emit(stream: TokenStream) -> TokenStream {
 ///
 /// Used for host code generation.
 #[cfg(feature = "event")]
-#[proc_macro_derive(EmitField, attributes(parent, field_name, field_ty))]
+#[proc_macro_derive(EmitField, attributes(parent, parent_field_name, parent_field_ty))]
 pub fn derive_emit_field(stream: TokenStream) -> TokenStream {
     event::emit::derive_field(stream)
 }
@@ -58,7 +58,7 @@ pub fn derive_listen(stream: TokenStream) -> TokenStream {
 ///
 /// Used for wasm code generation.
 #[cfg(feature = "event")]
-#[proc_macro_derive(ListenField, attributes(parent, field_ty))]
+#[proc_macro_derive(ListenField, attributes(parent, parent_field_ty))]
 pub fn derive_listen_field(stream: TokenStream) -> TokenStream {
     event::listen::derive_field(stream)
 }


### PR DESCRIPTION
- split macro handling
  - reduce duplicated sections in listen and emit derives
  - hopefully improved some naming to better understand the macro itself
- updated readme