### PR TITLE
Adjustable mod name

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ When using the derive macro `tauri_interop::Event` it expands depending on the `
 
 To emit a variable from the above struct (which is mostly intended to be used as state) in the host triplet
 ```rust , ignore-wasm32-unknown-unknown
-use tauri_interop::Event;
+use tauri_interop::{Event, event::emit::Emit};
 
 #[derive(Default, Event)]
 pub struct Test {

--- a/src/event.rs
+++ b/src/event.rs
@@ -35,17 +35,18 @@ where
     /// The type of the field
     type Type;
 
-    #[cfg(any(target_family = "wasm", feature = "wasm"))]
     /// The event of the field
     const EVENT_NAME: &'static str;
 
     #[cfg(not(target_family = "wasm"))]
     /// Emits event of the related field with their value
+    ///
+    /// not in wasm available
     fn emit(parent: &P, handle: &AppHandle<Wry>) -> Result<(), Error>;
 
     #[cfg(not(target_family = "wasm"))]
     /// Updates the related field and emit its event
     ///
-    /// Only required for "target_family = wasm"
+    /// not in wasm available
     fn update(s: &mut P, handle: &AppHandle<Wry>, v: Self::Type) -> Result<(), Error>;
 }

--- a/tauri-interop-macro/src/event.rs
+++ b/tauri-interop-macro/src/event.rs
@@ -1,7 +1,7 @@
 use convert_case::{Case, Casing};
 use proc_macro2::Ident;
 use quote::format_ident;
-use syn::{Attribute, DeriveInput, ItemStruct, Type};
+use syn::{Attribute, Data, DeriveInput, Type};
 
 pub(crate) mod emit;
 pub(crate) mod listen;
@@ -18,23 +18,29 @@ struct EventField {
     parent_field_ty: Type,
 }
 
-fn prepare_event(stream_struct: ItemStruct) -> EventStruct {
-    if stream_struct.fields.is_empty() {
+fn prepare_event(derive_input: DeriveInput) -> EventStruct {
+    let data_struct = match derive_input.data {
+        Data::Struct(data_struct) => data_struct,
+        _ => panic!("The macro only works with structs"),
+    };
+
+    if data_struct.fields.is_empty() {
         panic!("No fields provided")
     }
 
-    if stream_struct
-        .fields
-        .iter()
-        .any(|field| field.ident.is_none())
-    {
+    if data_struct.fields.iter().any(|field| field.ident.is_none()) {
         panic!("Tuple Structs aren't supported")
     }
 
-    let name = stream_struct.ident.clone();
-    let mod_name = format_ident!("{}", name.to_string().to_case(Case::Snake));
+    let name = derive_input.ident.clone();
+    let mod_name = derive_input
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("mod_name"))
+        .map(|attr| attr.parse_args::<Ident>().unwrap())
+        .unwrap_or(format_ident!("{}", name.to_string().to_case(Case::Snake)));
 
-    let fields = stream_struct
+    let fields = data_struct
         .fields
         .iter()
         .map(|field| {

--- a/tauri-interop-macro/src/event/emit.rs
+++ b/tauri-interop-macro/src/event/emit.rs
@@ -33,8 +33,6 @@ pub fn derive(stream: TokenStream) -> TokenStream {
     let event_fields = fields.iter().map(|field| &field.field_name);
 
     let stream = quote! {
-        use tauri_interop::event::{Field, emit::Emit};
-
         pub mod #mod_name {
             use super::#name;
             use tauri_interop::event::{Field, emit::Emit};
@@ -42,26 +40,29 @@ pub fn derive(stream: TokenStream) -> TokenStream {
             #( #emit_fields )*
         }
 
-        impl Emit for #name {
+        impl ::tauri_interop::event::emit::Emit for #name {
             fn emit_all(&self, handle: &::tauri::AppHandle) -> Result<(), ::tauri::Error> {
                 use #mod_name::*;
+                use ::tauri_interop::event::Field;
 
                 #( #event_fields::emit(self, handle)?; )*
 
                 Ok(())
             }
 
-            fn emit<F: Field<Self>>(&self, handle: &::tauri::AppHandle) -> Result<(), ::tauri::Error>
+            fn emit<F: ::tauri_interop::event::Field<Self>>(&self, handle: &::tauri::AppHandle) -> Result<(), ::tauri::Error>
             where
                 Self: Sized
             {
+                use ::tauri_interop::event::Field;
                 F::emit(self, handle)
             }
 
-            fn update<F: Field<Self>>(&mut self, handle: &::tauri::AppHandle, field: F::Type) -> Result<(), ::tauri::Error>
+            fn update<F: ::tauri_interop::event::Field<Self>>(&mut self, handle: &::tauri::AppHandle, field: F::Type) -> Result<(), ::tauri::Error>
             where
                 Self: Sized
             {
+                use ::tauri_interop::event::Field;
                 F::update(self, handle, field)
             }
         }

--- a/tauri-interop-macro/src/event/emit.rs
+++ b/tauri-interop-macro/src/event/emit.rs
@@ -1,12 +1,12 @@
 use proc_macro::TokenStream;
 
 use quote::{quote, ToTokens};
-use syn::{parse_macro_input, DeriveInput, ItemStruct};
+use syn::{parse_macro_input, DeriveInput};
 
 use crate::event::{EventField, EventStruct, Field, FieldAttributes};
 
 pub fn derive(stream: TokenStream) -> TokenStream {
-    let stream_struct = parse_macro_input!(stream as ItemStruct);
+    let stream_struct = parse_macro_input!(stream as DeriveInput);
     let EventStruct {
         name,
         mod_name,

--- a/tauri-interop-macro/src/event/emit.rs
+++ b/tauri-interop-macro/src/event/emit.rs
@@ -1,7 +1,7 @@
 use proc_macro::TokenStream;
 
 use quote::{quote, ToTokens};
-use syn::{parse_macro_input, DeriveInput};
+use syn::{DeriveInput, parse_macro_input};
 
 use crate::event::{EventField, EventStruct, Field, FieldAttributes};
 
@@ -93,6 +93,8 @@ pub fn derive_field(stream: TokenStream) -> TokenStream {
     let stream = quote! {
         impl Field<#parent> for #name {
             type Type = #parent_field_ty;
+
+            const EVENT_NAME: &'static str = #event_name;
 
             fn emit(parent: &#parent, handle: &::tauri::AppHandle) -> Result<(), ::tauri::Error> {
                 use ::tauri::Manager;

--- a/tauri-interop-macro/src/event/listen.rs
+++ b/tauri-interop-macro/src/event/listen.rs
@@ -1,12 +1,12 @@
 use proc_macro::TokenStream;
 
 use quote::{quote, ToTokens};
-use syn::{parse_macro_input, DeriveInput, ItemStruct};
+use syn::{parse_macro_input, DeriveInput};
 
 use crate::event::{EventField, EventStruct, Field, FieldAttributes};
 
 pub fn derive(stream: TokenStream) -> TokenStream {
-    let stream_struct = parse_macro_input!(stream as ItemStruct);
+    let stream_struct = parse_macro_input!(stream as DeriveInput);
     let EventStruct {
         name,
         mod_name,

--- a/tauri-interop-macro/src/lib.rs
+++ b/tauri-interop-macro/src/lib.rs
@@ -15,7 +15,7 @@ mod event;
 
 /// Conditionally adds [Listen] or [Emit] to a struct
 #[cfg(feature = "event")]
-#[proc_macro_derive(Event)]
+#[proc_macro_derive(Event, attributes(mod_name))]
 pub fn derive_event(stream: TokenStream) -> TokenStream {
     if cfg!(feature = "wasm") {
         event::listen::derive(stream)
@@ -30,7 +30,7 @@ pub fn derive_event(stream: TokenStream) -> TokenStream {
 ///
 /// Used for host code generation.
 #[cfg(feature = "event")]
-#[proc_macro_derive(Emit)]
+#[proc_macro_derive(Emit, attributes(mod_name))]
 pub fn derive_emit(stream: TokenStream) -> TokenStream {
     event::emit::derive(stream)
 }
@@ -49,7 +49,7 @@ pub fn derive_emit_field(stream: TokenStream) -> TokenStream {
 ///
 /// Used for wasm code generation
 #[cfg(feature = "event")]
-#[proc_macro_derive(Listen)]
+#[proc_macro_derive(Listen, attributes(mod_name))]
 pub fn derive_listen(stream: TokenStream) -> TokenStream {
     event::listen::derive(stream)
 }

--- a/tauri-interop-macro/src/lib.rs
+++ b/tauri-interop-macro/src/lib.rs
@@ -15,7 +15,7 @@ mod event;
 
 /// Conditionally adds [Listen] or [Emit] to a struct
 #[cfg(feature = "event")]
-#[proc_macro_derive(Event, attributes(mod_name))]
+#[proc_macro_derive(Event, attributes(auto_naming, mod_name))]
 pub fn derive_event(stream: TokenStream) -> TokenStream {
     if cfg!(feature = "wasm") {
         event::listen::derive(stream)
@@ -30,7 +30,7 @@ pub fn derive_event(stream: TokenStream) -> TokenStream {
 ///
 /// Used for host code generation.
 #[cfg(feature = "event")]
-#[proc_macro_derive(Emit, attributes(mod_name))]
+#[proc_macro_derive(Emit, attributes(auto_naming, mod_name))]
 pub fn derive_emit(stream: TokenStream) -> TokenStream {
     event::emit::derive(stream)
 }
@@ -49,7 +49,7 @@ pub fn derive_emit_field(stream: TokenStream) -> TokenStream {
 ///
 /// Used for wasm code generation
 #[cfg(feature = "event")]
-#[proc_macro_derive(Listen, attributes(mod_name))]
+#[proc_macro_derive(Listen, attributes(auto_naming, mod_name))]
 pub fn derive_listen(stream: TokenStream) -> TokenStream {
     event::listen::derive(stream)
 }

--- a/test-project/api/src/cmd.rs
+++ b/test-project/api/src/cmd.rs
@@ -44,24 +44,24 @@ pub fn result_test() -> Result<i32, String> {
 #[tauri_interop::command]
 pub fn emit(state: TauriState<RwLock<TestState>>, handle: TauriAppHandle) {
     use tauri_interop::event::emit::Emit;
-    // newly generated mod
-    use crate::model::test_state;
+    // newly generated mod, renamed to test_mod, default for TestState is test_state
+    use crate::model::test_mod;
 
     log::info!("emit cmd received");
 
     let mut state = state.write().unwrap();
 
     if state.bar {
-        state.update::<test_state::Bar>(&handle, false).unwrap();
+        state.update::<test_mod::Bar>(&handle, false).unwrap();
     } else {
         state
-            .update::<test_state::Foo>(&handle, "foo".into())
+            .update::<test_mod::Foo>(&handle, "foo".into())
             .unwrap();
     }
 
     state.bar = !state.bar;
     state
-        .emit::<test_state::Foo>(&handle)
+        .emit::<test_mod::Foo>(&handle)
         .unwrap();
 
     state.emit_all(&handle).unwrap();

--- a/test-project/api/src/model.rs
+++ b/test-project/api/src/model.rs
@@ -1,11 +1,36 @@
+#![allow(clippy::no_effect)]
+#![allow(dead_code)]
+#![allow(path_statements)]
+
 use tauri_interop::Event;
 
-#[allow(dead_code)]
 #[derive(Default, Event)]
 #[mod_name(test_mod)]
 pub struct TestState {
     foo: String,
     pub bar: bool,
+}
+
+#[derive(Default, Event)]
+#[auto_naming(EnumLike)]
+pub struct NamingTestEnum {
+    foo: String,
+    pub bar: bool,
+}
+
+#[derive(Default, Event)]
+pub struct NamingTestDefault {
+    foo: String,
+    pub bar: bool,
+}
+
+fn test_naming() {
+    test_mod::Bar;
+    test_mod::Foo;
+    NamingTestEnumField::Bar;
+    NamingTestEnumField::Foo;
+    naming_test_default::Bar;
+    naming_test_default::Foo;
 }
 
 // /// not allowed

--- a/test-project/api/src/model.rs
+++ b/test-project/api/src/model.rs
@@ -2,6 +2,7 @@ use tauri_interop::Event;
 
 #[allow(dead_code)]
 #[derive(Default, Event)]
+#[mod_name(test_mod)]
 pub struct TestState {
     foo: String,
     pub bar: bool,

--- a/test-project/src/main.rs
+++ b/test-project/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::disallowed_names)]
 
 use api::event::listen::Listen;
-use api::model::{test_state, TestState};
+use api::model::{test_mod, TestState};
 use gloo_timers::callback::Timeout;
 #[cfg(feature = "leptos")]
 use leptos::{component, create_signal, view, IntoView};
@@ -20,7 +20,7 @@ fn main() {
     });
 
     wasm_bindgen_futures::spawn_local(async move {
-        let handle_bar = TestState::listen_to::<test_state::Bar>(|echo| log::info!("bar: {echo}"))
+        let handle_bar = TestState::listen_to::<test_mod::Bar>(|echo| log::info!("bar: {echo}"))
             .await
             .unwrap();
 
@@ -47,7 +47,7 @@ fn App() -> impl IntoView {
     let (bar, set_bar) = create_signal(false);
 
     leptos::spawn_local(async move {
-        let handle_bar = TestState::listen_to::<test_state::Bar>(move |bar| set_bar.set(bar))
+        let handle_bar = TestState::listen_to::<test_mod::Bar>(move |bar| set_bar.set(bar))
             .await
             .unwrap();
 
@@ -71,7 +71,7 @@ fn App() -> impl IntoView {
 fn Foo() -> impl IntoView {
     Timeout::new(2000, api::cmd::emit).forget();
 
-    let (foo, _set_foo) = TestState::use_field::<test_state::Foo>("Test".into());
+    let (foo, _set_foo) = TestState::use_field::<test_mod::Foo>("Test".into());
 
     view! { <h1>{foo}</h1> }
 }


### PR DESCRIPTION
 - add option to just rename the mod
 - add auto_naming option
   - currently only "EnumLike" will work as option

The usage is shown as example in model.rs

Closes #3 