### PR TITLE
Resolve the existing underscore problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,6 @@ fn main() {
 ```
 
 ## Known Issues:
-- arguments used in `tauri::command` beginning with `_` aren't supported yet
-  - due to [tauri internally converting the argument name](https://tauri.app/v1/guides/features/command#passing-arguments), 
-    which results in losing the _ at the beginning
 - feature: leptos
   - sometimes a closure is accessed after being dropped
   - that is probably a race condition where the unlisten function doesn't detach the callback fast enough

--- a/tauri-interop-macro/src/command/wrapper.rs
+++ b/tauri-interop-macro/src/command/wrapper.rs
@@ -127,12 +127,16 @@ pub fn prepare(function: ItemFn) -> InvokeCommand {
                 false
             };
 
-            match typed.pat.as_ref() {
-                Pat::Ident(ident) => Some(FieldArg {
-                    ident: ident.ident.clone(),
-                    argument: fn_arg,
-                    requires_lifetime: req_lf,
-                }),
+            match typed.pat.as_mut() {
+                Pat::Ident(ident) => {
+                    // converting the ident to snake case, so it matches the expected snake case
+                    ident.ident = format_ident!("{}", ident.ident.to_string().to_case(Case::Snake));
+                    Some(FieldArg {
+                        ident: ident.ident.clone(),
+                        argument: fn_arg,
+                        requires_lifetime: req_lf,
+                    })
+                },
                 _ => None,
             }
         })

--- a/test-project/api/src/cmd.rs
+++ b/test-project/api/src/cmd.rs
@@ -11,6 +11,9 @@ tauri_interop::host_usage! {
 pub fn empty_invoke() {}
 
 #[tauri_interop::command]
+pub fn underscore_invoke(_invoke: u8) {}
+
+#[tauri_interop::command]
 pub async fn await_heavy_computing() {
     std::thread::sleep(std::time::Duration::from_millis(5000))
 }

--- a/test-project/src/main.rs
+++ b/test-project/src/main.rs
@@ -11,6 +11,7 @@ fn main() {
     console_error_panic_hook::set_once();
 
     api::cmd::empty_invoke();
+    api::cmd::underscore_invoke(69);
 
     wasm_bindgen_futures::spawn_local(async {
         log::info!("{}", api::cmd::greet("frontend").await);


### PR DESCRIPTION
- convert the fn_arg ident to snake_case to match tauris snake_case conversion
- update readme
- add test for the scenario

Closes #13 