### PR TITLE
Reduce the returned type of `use_field`

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,9 @@ as the event should be received. Dropping it will automatically detach the closu
 [cmd.rs](./test-project/api/src/cmd.rs) for other example how it could be used.
 
 #### Feature: leptos
-When the `leptos` feature is enabled it will add additional `use_<field>` methods on the provided struct.
-These methods take care of the required initial asynchronous call to register the listener and will hold the
-handle in scope as long as the component is rendered.
+When the `leptos` feature is enabled the `use_field` method is added to the `Listen` trait when compiling to wasm. 
+The method takes care of the initial asynchronous call to register the listener and will hold the handle in scope 
+as long as the leptos component is rendered.
 
 ```rust , ignore
 use tauri_interop::Event;
@@ -248,7 +248,7 @@ pub struct Test {
 fn main() {
   use tauri_interop::event::listen::Listen;
 
-  let (foo: leptos::ReadSignal<String>, set_foo: leptos::WriteSignal<String>) = Test::use_field::<test::Foo>(String::default());
+  let foo: leptos::ReadSignal<String> = Test::use_field::<test::Foo>(String::default());
 }
 ```
 

--- a/src/event/listen.rs
+++ b/src/event/listen.rs
@@ -1,6 +1,6 @@
 use js_sys::Function;
 #[cfg(feature = "leptos")]
-use leptos::{ReadSignal, WriteSignal};
+use leptos::ReadSignal;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 
@@ -87,10 +87,10 @@ impl ListenHandle {
 
     /// Registers a given event and binds a returned signal to these event changes
     ///
-    /// Internally it stores a created [ListenHandle] for `event` in a [leptos::RwSignal] to hold it
+    /// Internally it stores a created [ListenHandle] for `event` in a [leptos::RwSignal] to hold it in
     /// scope, while it is used in a [leptos::component](https://docs.rs/leptos_macro/0.5.2/leptos_macro/attr.component.html)
     #[cfg(feature = "leptos")]
-    pub fn use_register<T>(event: &'static str, initial_value: T) -> (ReadSignal<T>, WriteSignal<T>)
+    pub fn use_register<T>(event: &'static str, initial_value: T) -> ReadSignal<T>
     where
         T: DeserializeOwned,
     {
@@ -112,7 +112,7 @@ impl ListenHandle {
             handle.try_set(Some(listen_handle));
         });
 
-        (signal, set_signal)
+        signal
     }
 }
 
@@ -134,7 +134,7 @@ pub trait Listen {
     ///
     /// Default Implementation: see [ListenHandle::use_register]
     #[cfg(feature = "leptos")]
-    fn use_field<F: Field<Self>>(initial: F::Type) -> (ReadSignal<F::Type>, WriteSignal<F::Type>)
+    fn use_field<F: Field<Self>>(initial: F::Type) -> ReadSignal<F::Type>
     where
         Self: Sized + super::Parent,
     {

--- a/test-project/src/main.rs
+++ b/test-project/src/main.rs
@@ -71,7 +71,7 @@ fn App() -> impl IntoView {
 fn Foo() -> impl IntoView {
     Timeout::new(2000, api::cmd::emit).forget();
 
-    let (foo, _set_foo) = TestState::use_field::<test_mod::Foo>("Test".into());
+    let foo = TestState::use_field::<test_mod::Foo>("Test".into());
 
     view! { <h1>{foo}</h1> }
 }


### PR DESCRIPTION
- adjusted docs
- reduce type to `ReadSignal<T>`

Closes #14 