### PR TITLE
Usage inconveniences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3319,7 +3319,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-interop"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "js-sys",
  "leptos",
@@ -3327,7 +3327,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "tauri",
- "tauri-interop-macro 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tauri-interop-macro",
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3335,7 +3335,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-interop-macro"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "convert_case 0.6.0",
  "lazy_static",
@@ -3347,20 +3347,6 @@ dependencies = [
  "syn 2.0.52",
  "tauri",
  "tauri-interop",
-]
-
-[[package]]
-name = "tauri-interop-macro"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6107bb6b43eaa7663d5b5e6aa4558f81fad2589f21c9a069802432b0a0a6e4e"
-dependencies = [
- "convert_case 0.6.0",
- "lazy_static",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.52",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ description = "Easily connect your rust frontend and backend without writing dup
 readme = "README.md"
 
 [dependencies]
-#tauri-interop-macro = { path = "./tauri-interop-macro" }
-tauri-interop-macro = "2.1.1"
+tauri-interop-macro = { path = "./tauri-interop-macro" }
+#tauri-interop-macro = "2.1.1"
 
 js-sys = "0.3"
 serde = { version = "1.0", features = ["derive"] }
@@ -43,8 +43,8 @@ leptos = { version = "0.6", optional = true }
 tauri = { version = "1.6", default-features = false, features = ["wry"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-#tauri-interop-macro = { path = "./tauri-interop-macro", features = ["_wasm"] }
-tauri-interop-macro = { version = "2.1.1", features = [ "_wasm" ] }
+tauri-interop-macro = { path = "./tauri-interop-macro", features = ["_wasm"] }
+#tauri-interop-macro = { version = "2.1.1", features = [ "_wasm" ] }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tauri = "1.6"

--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ The crates therefore provides the following features:
 - collect and register all defined tauri-commands
 - QOL-macros to exclude multiple imports in wasm or the host architecture
 - easier usage of [tauri's event feature](https://tauri.app/v1/guides/features/events/)
+
+### Note
+
+The library uses a resolver 2 features to allow easy inclusion without configuration. When working with virtual 
+workspaces the resolver defaults to 1. In that case it is required to set the resolver manually to version 2,  
+otherwise the [target specific compilation](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies)
+will not resolve correctly. When the wrong resolver is used, an error should state that the `Listen` trait is missing.
+

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,6 +8,8 @@ pub use emit::*;
 #[cfg(any(target_family = "wasm", doc))]
 #[doc(cfg(target_family = "wasm"))]
 pub use listen::*;
+#[cfg(doc)]
+use tauri_interop_macro::{Emit, EmitField, Event, Listen, ListenField};
 
 /// traits for event emitting in the host code
 #[cfg(not(target_family = "wasm"))]
@@ -19,7 +21,34 @@ mod emit;
 #[doc(cfg(target_family = "wasm"))]
 mod listen;
 
+#[allow(clippy::needless_doctest_main)]
 /// Trait defining a [Field] to a related struct implementing [Parent] with the related [Field::Type]
+///
+/// When using [Event], [Emit] or [Listen], for each field of the struct, a struct named after the 
+/// field is generated. The field naming is snake_case to PascalCase, but because of the possibility
+/// that the type and the field name are the same, the generated field has a "F" appended at the 
+/// beginning to separate each other and avoid type collision.
+/// 
+/// ```
+/// use serde::{Deserialize, Serialize};
+/// use tauri_interop::{Event, event::ManagedEmit};
+/// 
+/// #[derive(Default, Clone, Serialize, Deserialize)]
+/// struct Bar {
+///     foo: u16
+/// }
+///
+/// #[derive(Event)]
+/// struct Test {
+///     bar: Bar
+/// }
+/// 
+/// impl ManagedEmit for Test {}
+///
+/// fn main() {
+///     let _ = test::FBar;
+/// }
+/// ```
 pub trait Field<P>
 where
     P: Parent,

--- a/src/event/emit.rs
+++ b/src/event/emit.rs
@@ -89,7 +89,7 @@ pub trait Emit: Sized {
     /// 
     /// #[tauri_interop::command]
     /// fn emit_bar(handle: TauriAppHandle) {
-    ///     Test::default().emit::<test::Foo>(&handle).expect("emitting failed");
+    ///     Test::default().emit::<test::FFoo>(&handle).expect("emitting failed");
     /// }
     ///
     /// fn main() {}
@@ -116,7 +116,7 @@ pub trait Emit: Sized {
     ///
     /// #[tauri_interop::command]
     /// fn emit_bar(handle: TauriAppHandle) {
-    ///     Test::default().update::<test::Bar>(&handle, true).expect("emitting failed");
+    ///     Test::default().update::<test::FBar>(&handle, true).expect("emitting failed");
     /// }
     ///
     /// fn main() {}

--- a/src/event/emit.rs
+++ b/src/event/emit.rs
@@ -36,7 +36,7 @@ where
         get_field_value: impl Fn(&Self) -> F::Type,
     ) -> Option<F::Type>
     where
-        Self: Sized + Send + Sync,
+        Self: Send + Sync,
     {
         use tauri::Manager;
 
@@ -47,7 +47,7 @@ where
 }
 
 /// Trait that defines the available event emitting methods
-pub trait Emit {
+pub trait Emit: Sized {
     /// Emit all field events
     ///
     /// ### Example
@@ -96,7 +96,7 @@ pub trait Emit {
     /// ```
     fn emit<F: Field<Self>>(&self, handle: &AppHandle<Wry>) -> Result<(), Error>
     where
-        Self: Sized + Parent;
+        Self: Parent;
 
     /// Update a single field and emit it afterward
     ///
@@ -127,5 +127,5 @@ pub trait Emit {
         field: F::Type,
     ) -> Result<(), Error>
     where
-        Self: Sized + Parent;
+        Self: Parent;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,14 @@
 //!
 //! Detail explanations and example can be found on the respected traits or macros. Some
 //! examples are ignored because they are only valid when compiling to wasm.
+//!
+//! ### Note
+//!
+//! The library uses resolver 2 features to allow easy inclusion without configuration. When working
+//! with virtual workspaces the resolver defaults to 1 in which case it is required to set the
+//! resolver manually to version 2, otherwise the [target specific compilation](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies)
+//! will not resolve correctly. When the wrong resolver is used, an error should state that the
+//! [event::Listen] trait is missing.
 
 #![feature(trait_alias)]
 #![feature(doc_cfg)]

--- a/tauri-interop-macro/Cargo.toml
+++ b/tauri-interop-macro/Cargo.toml
@@ -27,7 +27,7 @@ proc-macro-error = "1.0.4"
 [dev-dependencies]
 tauri = { version = "^1.6", default-features = false, features = ["wry"] }
 log = "^0.4"
-serde = "^1.0"
+serde = { version = "^1.0", features = [ "derive" ] }
 # required because the intented usage is to use the main crate,
 # for testing we need the reexported macros from tauri-interop
 tauri-interop = { path = "..", features = ["event", "initial_value"] }

--- a/tauri-interop-macro/src/event.rs
+++ b/tauri-interop-macro/src/event.rs
@@ -57,7 +57,7 @@ fn prepare_event(derive_input: DeriveInput) -> EventStruct {
         .iter()
         .map(|field| {
             let field_ident = field.ident.as_ref().unwrap();
-            let field_name = format_ident!("{}", field_ident.to_string().to_case(Case::Pascal));
+            let field_name = format_ident!("F{}", field_ident.to_string().to_case(Case::Pascal));
 
             EventField {
                 field_name,

--- a/tauri-interop-macro/src/event/emit.rs
+++ b/tauri-interop-macro/src/event/emit.rs
@@ -41,7 +41,7 @@ pub fn derive(stream: TokenStream) -> TokenStream {
     let stream = quote! {
         #commands_attr
         pub mod #mod_name {
-            use super::#name;
+            use super::*;
 
             #( #emit_fields )*
 

--- a/tauri-interop-macro/src/event/listen.rs
+++ b/tauri-interop-macro/src/event/listen.rs
@@ -31,8 +31,7 @@ pub fn derive(stream: TokenStream) -> TokenStream {
 
     let stream = quote! {
         pub mod #mod_name {
-            use super::#name;
-            use ::tauri_interop::event::Field;
+            use super::*;
 
             #( #listen_fields )*
         }
@@ -74,7 +73,7 @@ pub fn derive_field(stream: TokenStream) -> TokenStream {
     let stream = quote! {
         #get_cmd_fn
         
-        impl Field<#parent> for #name {
+        impl ::tauri_interop::event::Field<#parent> for #name {
             type Type = #parent_field_ty;
             const EVENT_NAME: &'static str = #event_name;
             

--- a/tauri-interop-macro/src/lib.rs
+++ b/tauri-interop-macro/src/lib.rs
@@ -42,11 +42,17 @@ mod event;
 ///
 /// ```
 /// use tauri_interop_macro::Event;
+/// use serde::{Serialize, Deserialize};
 ///
+/// #[derive(Default, Clone, Serialize, Deserialize)]
+/// pub struct Bar {
+///     value: bool
+/// }
+/// 
 /// #[derive(Event)]
 /// struct EventModel {
 ///     foo: String,
-///     pub bar: bool
+///     pub bar: Bar
 /// }
 /// 
 /// impl tauri_interop::event::ManagedEmit for EventModel {}

--- a/test-project/Cargo.lock
+++ b/test-project/Cargo.lock
@@ -3500,8 +3500,6 @@ dependencies = [
 [[package]]
 name = "tauri-interop-macro"
 version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5d064725d13c1bf969fa8d7cc00a0d2cb6ac617d68d1eb9b45d600c9a353d7"
 dependencies = [
  "convert_case 0.6.0",
  "lazy_static",

--- a/test-project/Cargo.lock
+++ b/test-project/Cargo.lock
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-interop"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "js-sys",
  "leptos",
@@ -3499,9 +3499,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-interop-macro"
-version = "2.0.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbfaea1629f9987e8817846addaffef3b24ab5e132e584f371625e9d49b4191"
+checksum = "9b5d064725d13c1bf969fa8d7cc00a0d2cb6ac617d68d1eb9b45d600c9a353d7"
 dependencies = [
  "convert_case 0.6.0",
  "lazy_static",

--- a/test-project/Cargo.toml
+++ b/test-project/Cargo.toml
@@ -10,7 +10,7 @@ default-target = "wasm32-unknown-unknown"
 members = ["src-tauri", "api"]
 
 [dependencies]
-api = { path = "./api", default-features = false, features = [ "wasm" ]}
+api = { path = "./api" }
 
 console_error_panic_hook = "^0.1"
 console_log = "^1.0"

--- a/test-project/api/Cargo.toml
+++ b/test-project/api/Cargo.toml
@@ -4,24 +4,21 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tauri-interop = { path = "../..", default-features = false, features = ["event", "initial_value"] }
+tauri-interop = { path = "../..", features = ["event", "initial_value"] }
 
 # common
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 
-# host target
-tauri = { version = "1.6", optional = true }
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+tauri = { version = "1.6" }
 
-# wasm target
-js-sys = { version = "0.3", optional = true }
-serde-wasm-bindgen = { version = "0.6", optional = true }
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"], optional = true }
-wasm-bindgen-futures = {version = "0.4", optional = true}
+[target.'cfg(target_family = "wasm")'.dependencies]
+js-sys = { version = "0.3" }
+serde-wasm-bindgen = { version = "0.6" }
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen-futures = { version = "0.4" }
 leptos = { version = "0.6", features = ["csr"], optional = true }
 
 [features]
-default = [ "host" ]
-host    = [ "dep:tauri" ]
-wasm    = [ "dep:js-sys", "dep:serde-wasm-bindgen", "dep:wasm-bindgen", "dep:wasm-bindgen-futures"]
-leptos  = [ "dep:leptos", "tauri-interop/leptos" ]
+leptos = ["dep:leptos", "tauri-interop/leptos"]

--- a/test-project/api/src/cmd.rs
+++ b/test-project/api/src/cmd.rs
@@ -61,8 +61,8 @@ pub fn emit(state: TauriState<RwLock<TestState>>, handle: TauriAppHandle) {
         "foo"
     };
 
-    state.update::<test_mod::Foo>(&handle, foo_value.into()).unwrap();
-    state.update::<test_mod::Bar>(&handle, bar_value).unwrap();
+    state.update::<test_mod::FFoo>(&handle, foo_value.into()).unwrap();
+    state.update::<test_mod::FBar>(&handle, bar_value).unwrap();
 }
 
 tauri_interop::collect_commands!();

--- a/test-project/api/src/model.rs
+++ b/test-project/api/src/model.rs
@@ -32,12 +32,12 @@ pub struct NamingTestDefault {
 }
 
 fn test_naming() {
-    test_mod::Bar;
-    test_mod::Foo;
-    NamingTestEnumField::Bar;
-    NamingTestEnumField::Foo;
-    naming_test_default::Bar;
-    naming_test_default::Foo;
+    test_mod::FBar;
+    test_mod::FFoo;
+    NamingTestEnumField::FBar;
+    NamingTestEnumField::FFoo;
+    naming_test_default::FBar;
+    naming_test_default::FFoo;
 }
 
 // /// not allowed

--- a/test-project/src-tauri/Cargo.toml
+++ b/test-project/src-tauri/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-api = { path = "../api"}
+api = { path = "../api" }
 
 tauri = { version = "1.5", features = ["shell-open"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/test-project/src/main.rs
+++ b/test-project/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
     });
 
     wasm_bindgen_futures::spawn_local(async move {
-        let handle_bar = TestState::listen_to::<test_mod::Bar>(|echo| log::info!("bar: {echo}"))
+        let handle_bar = TestState::listen_to::<test_mod::FBar>(|echo| log::info!("bar: {echo}"))
             .await
             .unwrap();
 
@@ -45,7 +45,7 @@ fn main() {
 fn App() -> impl IntoView {
     use leptos::SignalGet;
 
-    let bar = TestState::use_field::<test_mod::Bar>(Some(true));
+    let bar = TestState::use_field::<test_mod::FBar>(Some(true));
 
     let exit = move |_| api::model::other_cmd::stop_application();
 
@@ -71,7 +71,7 @@ fn Foo() -> impl IntoView {
         api::cmd::emit();
     }).forget();
 
-    let foo = TestState::use_field::<test_mod::Foo>(None);
+    let foo = TestState::use_field::<test_mod::FFoo>(None);
 
     view! { <h1>{foo}</h1> }
 }


### PR DESCRIPTION
- added note when using virtual workspaces and related compilation errors
- append `F` to auto generated Fields so that no type collision can occur
- remove some repetitive code 
   - super::Parent -> Parent
   - Emit and Listen are now Sized bound by the trait itself
- added some documentation to reflect the rename changes
- updated the test-project to use `platform specific dependencies` instead of features that need to be invoke