### PR TITLE
Add `ManagedEmit` as derive macro

### DIFF
--- a/tauri-interop-macro/src/event/emit.rs
+++ b/tauri-interop-macro/src/event/emit.rs
@@ -136,3 +136,14 @@ pub fn derive_field(stream: TokenStream) -> TokenStream {
 
     TokenStream::from(stream.to_token_stream())
 }
+
+#[cfg(feature = "initial_value")]
+pub fn derive_managed_emit(stream: TokenStream) -> TokenStream {
+    let stream_struct = parse_macro_input!(stream as DeriveInput);
+    let struct_ident = stream_struct.ident;
+
+    let stream = quote! {
+        impl ::tauri_interop::event::ManagedEmit for #struct_ident {}
+    };
+    TokenStream::from(stream.to_token_stream())
+}

--- a/tauri-interop-macro/src/lib.rs
+++ b/tauri-interop-macro/src/lib.rs
@@ -56,6 +56,7 @@ mod event;
 ///     pub bar: Bar
 /// }
 ///
+/// #[cfg(feature = "initial_value")]
 /// impl tauri_interop::event::ManagedEmit for EventModel {}
 ///
 /// // has to be defined in this example, otherwise the
@@ -71,6 +72,32 @@ pub fn derive_event(stream: TokenStream) -> TokenStream {
     } else {
         event::emit::derive(stream)
     }
+}
+
+/// Auto implements the `ManagedEmit` trait from `tauri_interop` when compiling to the host
+///
+/// ### Example
+///
+/// ```
+/// use tauri_interop_macro::{Event, ManagedEmit};
+///
+/// #[derive(Event, ManagedEmit)]
+/// struct EventModel {
+///     foo: String,
+///     pub bar: bool
+/// }
+///
+/// // has to be defined in this example, otherwise the
+/// // macro expansion panics because of missing super
+/// fn main() {}
+/// ```
+#[cfg(all(feature = "event", feature = "initial_value"))]
+#[doc(cfg(all(feature = "event", feature = "initial_value")))]
+#[proc_macro_derive(ManagedEmit)]
+pub fn derive_managed_emit(stream: TokenStream) -> TokenStream {
+    (!cfg!(feature = "_wasm"))
+        .then(|| event::emit::derive_managed_emit(stream))
+        .unwrap_or_default()
 }
 
 /// Generates a default `Emit` implementation for the given struct.

--- a/test-project/api/src/model.rs
+++ b/test-project/api/src/model.rs
@@ -9,7 +9,7 @@ mod host_impl;
 #[tauri_interop::commands]
 pub mod other_cmd;
 
-use tauri_interop::Event;
+use tauri_interop::{Event, ManagedEmit};
 
 #[derive(Default, Event)]
 #[mod_name(test_mod)]
@@ -18,14 +18,14 @@ pub struct TestState {
     pub bar: bool,
 }
 
-#[derive(Default, Event)]
+#[derive(Default, Event, ManagedEmit)]
 #[auto_naming(EnumLike)]
 pub struct NamingTestEnum {
     foo: String,
     pub bar: bool,
 }
 
-#[derive(Default, Event)]
+#[derive(Default, Event, ManagedEmit)]
 pub struct NamingTestDefault {
     foo: String,
     pub bar: bool,

--- a/test-project/api/src/model/host_impl.rs
+++ b/test-project/api/src/model/host_impl.rs
@@ -13,6 +13,3 @@ impl ManagedEmit for super::TestState {
         Some(get_field_value(&state))
     }
 }
-
-impl ManagedEmit for super::NamingTestEnum {}
-impl ManagedEmit for super::NamingTestDefault {}


### PR DESCRIPTION
Instead of having to write `impl ManagedEmit for <struct> {}`, `ManagedEmit` can now simply be derived and will only be implemented when compiling to the host.